### PR TITLE
Update hdsfhir to reflect (inconsistent) representations of codes in HDS

### DIFF
--- a/allergy.go
+++ b/allergy.go
@@ -4,8 +4,8 @@ import fhir "github.com/intervention-engine/fhir/models"
 
 type Allergy struct {
 	Entry
-	Reaction CodeMap `json:"reaction"`
-	Severity CodeMap `json:"severity"`
+	Reaction *CodeObject `json:"reaction"`
+	Severity *CodeObject `json:"severity"`
 }
 
 func (a *Allergy) FHIRModels() []interface{} {
@@ -19,7 +19,7 @@ func (a *Allergy) FHIRModels() []interface{} {
 	fhirAllergy.Substance = a.Codes.FHIRCodeableConcept(a.Description)
 	fhirAllergy.Status = a.convertStatus()
 	fhirAllergy.Criticality = a.convertCriticality()
-	if len(a.Reaction) != 0 {
+	if a.Reaction != nil {
 		cc := a.Reaction.FHIRCodeableConcept("")
 		fhirAllergy.Reaction = []fhir.AllergyIntoleranceReactionComponent{
 			{Manifestation: []fhir.CodeableConcept{*cc}},
@@ -65,7 +65,7 @@ func (a *Allergy) convertStatus() string {
 //   http://hl7.org/fhir/DSTU2/valueset-allergy-intolerance-criticality.html
 // If the severity can't be mapped, criticality will be left blank
 func (a *Allergy) convertCriticality() string {
-	if len(a.Severity) == 0 {
+	if a.Severity == nil {
 		return ""
 	}
 

--- a/code_map.go
+++ b/code_map.go
@@ -19,6 +19,20 @@ func (c *CodeMap) FHIRCodeableConcept(text string) *fhir.CodeableConcept {
 	return concept
 }
 
+type CodeObject struct {
+	Code       string `json:"code"`
+	CodeSystem string `json:"codeSystem"`
+}
+
+func (c *CodeObject) FHIRCodeableConcept(text string) *fhir.CodeableConcept {
+	concept := &fhir.CodeableConcept{}
+	concept.Coding = []fhir.Coding{
+		{System: CodeSystemMap[c.CodeSystem], Code: c.Code},
+	}
+	concept.Text = text
+	return concept
+}
+
 var CodeSystemMap = map[string]string{
 	"CPT":                             "http://www.ama-assn.org/go/cpt",
 	"LOINC":                           "http://loinc.org",

--- a/code_map_test.go
+++ b/code_map_test.go
@@ -19,3 +19,12 @@ func (s *CodeMapSuite) TestCodeMapToCodeableConcept(c *C) {
 	c.Assert(concept.MatchesCode("http://snomed.info/sct", "5678"), Equals, true)
 	c.Assert(concept.MatchesCode("http://www.ama-assn.org/go/cpt", "abcd"), Equals, true)
 }
+
+func (s *CodeMapSuite) TestCodeObjectToCodeableConcept(c *C) {
+	codeObj := CodeObject{CodeSystem: "SNOMED-CT", Code: "1234"}
+
+	concept := codeObj.FHIRCodeableConcept("test")
+	c.Assert(concept.Text, Equals, "test")
+	c.Assert(concept.Coding, HasLen, 1)
+	c.Assert(concept.MatchesCode("http://snomed.info/sct", "1234"), Equals, true)
+}

--- a/condition.go
+++ b/condition.go
@@ -4,6 +4,8 @@ import fhir "github.com/intervention-engine/fhir/models"
 
 type Condition struct {
 	Entry
+	// NOTE: HDS has inconsistent representations of severity, but the only working importer (cat1)
+	// models it like a CodeMap -- so that's what we assume.  Note the difference from Allergy.
 	Severity CodeMap `json:"severity"`
 }
 

--- a/encounter.go
+++ b/encounter.go
@@ -4,8 +4,8 @@ import fhir "github.com/intervention-engine/fhir/models"
 
 type Encounter struct {
 	Entry
-	Reason               CodeMap `json:"reason"`
-	DischargeDisposition CodeMap `json:"dischargeDisposition"`
+	Reason               *Entry      `json:"reason"`
+	DischargeDisposition *CodeObject `json:"dischargeDisposition"`
 }
 
 func (e *Encounter) FHIRModels() []interface{} {
@@ -15,11 +15,11 @@ func (e *Encounter) FHIRModels() []interface{} {
 	fhirEncounter.Type = []fhir.CodeableConcept{*typeConcept}
 	fhirEncounter.Patient = e.Patient.FHIRReference()
 	fhirEncounter.Period = e.GetFHIRPeriod()
-	if len(e.Reason) > 0 {
-		reasonConcept := e.Reason.FHIRCodeableConcept("")
+	if e.Reason != nil && len(e.Reason.Codes) > 0 {
+		reasonConcept := e.Reason.Codes.FHIRCodeableConcept("")
 		fhirEncounter.Reason = []fhir.CodeableConcept{*reasonConcept}
 	}
-	if len(e.DischargeDisposition) > 0 {
+	if e.DischargeDisposition != nil {
 		fhirEncounter.Hospitalization = &fhir.EncounterHospitalizationComponent{
 			DischargeDisposition: e.DischargeDisposition.FHIRCodeableConcept(""),
 		}

--- a/entry.go
+++ b/entry.go
@@ -4,17 +4,17 @@ import fhir "github.com/intervention-engine/fhir/models"
 
 type Entry struct {
 	TemporallyIdentified
-	Patient        *Patient `json:"-"`
-	StartTime      UnixTime `json:"start_time"`
-	EndTime        UnixTime `json:"end_time"`
-	Time           UnixTime `json:"time"`
-	Oid            string   `json:"oid"`
-	Codes          CodeMap  `json:"codes"`
-	MoodCode       string   `json:"mood_code"`
-	NegationInd    bool     `json:"negationInd"`
-	NegationReason CodeMap  `json:"negationReason"`
-	StatusCode     CodeMap  `json:"status_code"`
-	Description    string   `json:"description"`
+	Patient        *Patient    `json:"-"`
+	StartTime      UnixTime    `json:"start_time"`
+	EndTime        UnixTime    `json:"end_time"`
+	Time           UnixTime    `json:"time"`
+	Oid            string      `json:"oid"`
+	Codes          CodeMap     `json:"codes"`
+	MoodCode       string      `json:"mood_code"`
+	NegationInd    bool        `json:"negationInd"`
+	NegationReason *CodeObject `json:"negationReason"`
+	StatusCode     CodeMap     `json:"status_code"`
+	Description    string      `json:"description"`
 }
 
 func (e *Entry) GetFHIRPeriod() *fhir.Period {

--- a/fixtures/allergies.json
+++ b/fixtures/allergies.json
@@ -10,14 +10,12 @@
     "description" : "Medication, Allergy: Influenza Vaccine (Code List: 2.16.840.1.113883.3.526.3.1254)",
     "start_time" : 1325396520,
     "severity": {
-      "SNOMED-CT": [
-        "371924009"
-      ]
+      "codeSystem": "SNOMED-CT",
+      "code": "371924009"
     },
     "reaction": {
-      "SNOMED-CT": [
-        "421581006"
-      ]
+      "codeSystem": "SNOMED-CT",
+      "code": "421581006"
     },
     "status_code" : {
       "SNOMED-CT": [
@@ -92,9 +90,8 @@
     "description" : "Medication, Allergy: Influenza Vaccine (Code List: 2.16.840.1.113883.3.526.3.1254)",
     "start_time" : 1325396520,
     "severity": {
-      "SNOMED-CT": [
-        "255604002"
-      ]
+      "codeSystem": "SNOMED-CT",
+      "code": "255604002"
     },
     "status_code" : {
       "SNOMED-CT": [
@@ -115,9 +112,8 @@
     "description" : "Medication, Allergy: Influenza Vaccine (Code List: 2.16.840.1.113883.3.526.3.1254)",
     "start_time" : 1325396520,
     "severity": {
-      "SNOMED-CT": [
-        "6736007"
-      ]
+      "codeSystem": "SNOMED-CT",
+      "code": "6736007"
     },
     "status_code" : {
       "SNOMED-CT": [

--- a/fixtures/encounters.json
+++ b/fixtures/encounters.json
@@ -50,9 +50,11 @@
     "oid": "2.16.840.1.113883.3.560.1.83",
     "performer_id": null,
     "reason": {
-      "SNOMED-CT": [
-        "2070002"
-      ]
+      "codes": {
+        "SNOMED-CT": [
+          "2070002"
+        ]
+      }
     },
     "specifics": null,
     "start_time": 1320148800,
@@ -77,9 +79,8 @@
     },
     "description": "Encounter, Performed: Inpatient Encounter",
     "dischargeDisposition": {
-      "NUBC": [
-        "1"
-      ]
+      "codeSystem": "NUBC",
+      "code": "1"
     },
     "dischargeTime": null,
     "end_time": 1320152400,

--- a/fixtures/immunizations.json
+++ b/fixtures/immunizations.json
@@ -21,9 +21,8 @@
     "description": "MMR",
     "negationInd": true,
     "negationReason": {
-      "SNOMED-CT": [
-        "591000119102"
-      ]
+      "codeSystem": "SNOMED-CT",
+      "code": "591000119102"
     },
     "_type": "Immunization"
   }

--- a/fixtures/john_peters.json
+++ b/fixtures/john_peters.json
@@ -587,14 +587,12 @@
         "description" : "Medication, Allergy: Influenza Vaccine (Code List: 2.16.840.1.113883.3.526.3.1254)",
         "start_time" : 1325396520,
         "severity": {
-          "SNOMED-CT": [
-            "371924009"
-          ]
+          "codeSystem": "SNOMED-CT",
+          "code": "371924009"
         },
         "reaction": {
-          "SNOMED-CT": [
-            "421581006"
-          ]
+          "codeSystem": "SNOMED-CT",
+          "code": "421581006"
         },
         "status_code" : {
           "SNOMED-CT": [

--- a/fixtures/medications.json
+++ b/fixtures/medications.json
@@ -96,9 +96,8 @@
     "mood_code": "EVN",
     "negationInd": true,
     "negationReason": {
-      "SNOMED-CT": [
-        "416098002"
-      ]
+      "codeSystem": "SNOMED-CT",
+      "code": "416098002"
     },
     "oid": "2.16.840.1.113883.3.560.1.17",
     "patientInstructions": null,
@@ -180,9 +179,8 @@
     "mood_code": "EVN",
     "negationInd": true,
     "negationReason": {
-      "SNOMED-CT": [
-        "591000119102"
-      ]
+      "codeSystem": "SNOMED-CT",
+      "code": "591000119102"
     },
     "oid": "2.16.840.1.113883.3.560.1.14",
     "patientInstructions": null,

--- a/fixtures/procedures.json
+++ b/fixtures/procedures.json
@@ -72,9 +72,8 @@
     },
     "description": "Procedure, Performed: Hospital measures-CABG",
     "anatomical_target": {
-      "SNOMED-CT": [
-        "50018008"
-      ]
+      "codeSystem": "SNOMED-CT",
+      "code": "50018008"
     },
     "end_time": 1362242700,
     "incisionTime": null,
@@ -112,9 +111,8 @@
     },
     "description": "Procedure, Ordered: Hospital measures-CABG",
     "anatomical_target": {
-      "SNOMED-CT": [
-        "50018008"
-      ]
+      "codeSystem": "SNOMED-CT",
+      "code": "50018008"
     },
     "end_time": 1362239100,
     "incisionTime": null,
@@ -156,9 +154,8 @@
     "mood_code": "EVN",
     "negationInd": true,
     "negationReason": {
-      "SNOMED-CT": [
-        "397807004"
-      ]
+      "codeSystem": "SNOMED-CT",
+      "code": "397807004"
     },
     "oid": "2.16.840.1.113883.3.560.1.6",
     "ordinality": null,
@@ -191,9 +188,8 @@
     },
     "description": "Procedure, Ordered: Hospital measures-CABG",
     "anatomical_target": {
-      "SNOMED-CT": [
-        "50018008"
-      ]
+      "codeSystem": "SNOMED-CT",
+      "code": "50018008"
     },
     "end_time": 1362239100,
     "incisionTime": null,

--- a/fixtures/vital_signs.json
+++ b/fixtures/vital_signs.json
@@ -8,9 +8,8 @@
     "description": "Laboratory Test, Result: HbA1c Laboratory Test",
     "end_time": 1320149800,
     "interpretation": {
-      "HL7 Observation Interpretation": [
-        "A"
-      ]
+      "codeSystem": "HL7 Observation Interpretation",
+      "code": "A"
     },
     "mood_code": "EVN",
     "negationInd": null,

--- a/immunization.go
+++ b/immunization.go
@@ -17,7 +17,7 @@ func (i *Immunization) FHIRModels() []interface{} {
 		t := true
 		fhirImmunization.WasNotGiven = &t
 	}
-	if len(i.NegationReason) > 0 {
+	if i.NegationReason != nil {
 		cc := i.NegationReason.FHIRCodeableConcept("")
 		fhirImmunization.Explanation = &fhir.ImmunizationExplanationComponent{
 			ReasonNotGiven: []fhir.CodeableConcept{*cc},

--- a/medication.go
+++ b/medication.go
@@ -25,7 +25,7 @@ func (m *Medication) convertMedication() []interface{} {
 		t := true
 		fhirMedicationStatement.WasNotTaken = &t
 	}
-	if len(m.NegationReason) > 0 {
+	if m.NegationReason != nil {
 		cc := m.NegationReason.FHIRCodeableConcept("")
 		fhirMedicationStatement.ReasonNotTaken = []fhir.CodeableConcept{*cc}
 	}
@@ -87,7 +87,7 @@ func (m *Medication) convertImmunization() []interface{} {
 		t := true
 		fhirImmunization.WasNotGiven = &t
 	}
-	if len(m.NegationReason) > 0 {
+	if m.NegationReason != nil {
 		cc := m.NegationReason.FHIRCodeableConcept("")
 		fhirImmunization.Explanation = &fhir.ImmunizationExplanationComponent{
 			ReasonNotGiven: []fhir.CodeableConcept{*cc},

--- a/procedure.go
+++ b/procedure.go
@@ -4,7 +4,7 @@ import fhir "github.com/intervention-engine/fhir/models"
 
 type Procedure struct {
 	Entry
-	AnatomicalTarget CodeMap       `json:"anatomical_target"`
+	AnatomicalTarget *CodeObject   `json:"anatomical_target"`
 	Values           []ResultValue `json:"values"`
 }
 
@@ -51,11 +51,11 @@ func (p *Procedure) convertProcedure() []interface{} {
 		t := true
 		fhirProcedure.NotPerformed = &t
 	}
-	if len(p.NegationReason) > 0 {
+	if p.NegationReason != nil {
 		cc := p.NegationReason.FHIRCodeableConcept("")
 		fhirProcedure.ReasonNotPerformed = []fhir.CodeableConcept{*cc}
 	}
-	if len(p.AnatomicalTarget) > 0 {
+	if p.AnatomicalTarget != nil {
 		cc := p.AnatomicalTarget.FHIRCodeableConcept("")
 		fhirProcedure.BodySite = []fhir.CodeableConcept{*cc}
 	}
@@ -132,7 +132,7 @@ func (p *Procedure) convertProcedureRequest() []interface{} {
 	fhirProcedureRequest.Subject = p.Patient.FHIRReference()
 	fhirProcedureRequest.Status = p.convertProcedureRequestStatus()
 	fhirProcedureRequest.Code = p.Codes.FHIRCodeableConcept(p.Description)
-	if len(p.AnatomicalTarget) > 0 {
+	if p.AnatomicalTarget != nil {
 		cc := p.AnatomicalTarget.FHIRCodeableConcept("")
 		fhirProcedureRequest.BodySite = []fhir.CodeableConcept{*cc}
 	}

--- a/vital_sign.go
+++ b/vital_sign.go
@@ -5,7 +5,7 @@ import fhir "github.com/intervention-engine/fhir/models"
 type VitalSign struct {
 	Entry
 	Description    string        `json:"description"`
-	Interpretation CodeMap       `json:"interpretation"`
+	Interpretation *CodeObject   `json:"interpretation"`
 	Values         []ResultValue `json:"values"`
 }
 
@@ -22,7 +22,7 @@ func (v *VitalSign) FHIRModels() []interface{} {
 	fhirObservation.Code = v.Codes.FHIRCodeableConcept(v.Description)
 	fhirObservation.Encounter = v.Patient.MatchingEncounterReference(v.Entry)
 	fhirObservation.EffectivePeriod = v.GetFHIRPeriod()
-	if len(v.Interpretation) > 0 {
+	if v.Interpretation != nil {
 		fhirObservation.Interpretation = v.Interpretation.FHIRCodeableConcept("")
 	}
 	fhirObservation.Subject = v.Patient.FHIRReference()


### PR DESCRIPTION
As it turns out, HDS has two different representations of codes:
```json
{
  "SNOMED-CT": [
    "12345"
  ]
}
```
and:
```json
{
  "codeSystem": "SNOMED-CT",
  "code": "12345"
}
```

Our code only accounted for the first representation.  Now we use the correct representation in the correct places (as best I can tell based on the HDS ruby code).