### PR TITLE
Base Resource Support

### DIFF
--- a/allergy.go
+++ b/allergy.go
@@ -9,7 +9,8 @@ type Allergy struct {
 }
 
 func (a *Allergy) FHIRModels() []interface{} {
-	fhirAllergy := &fhir.AllergyIntolerance{Id: a.GetTempID()}
+	fhirAllergy := &fhir.AllergyIntolerance{}
+	fhirAllergy.Id = a.GetTempID()
 	if a.StartTime != 0 {
 		fhirAllergy.Onset = a.StartTime.FHIRDateTime()
 	} else if a.Time != 0 {

--- a/condition.go
+++ b/condition.go
@@ -10,7 +10,8 @@ type Condition struct {
 }
 
 func (c *Condition) FHIRModels() []interface{} {
-	fhirCondition := &fhir.Condition{Id: c.GetTempID()}
+	fhirCondition := &fhir.Condition{}
+	fhirCondition.Id = c.GetTempID()
 	fhirCondition.Patient = c.Patient.FHIRReference()
 	fhirCondition.Code = c.Codes.FHIRCodeableConcept(c.Description)
 	// TODO: consider setting category to "diagnosis"

--- a/encounter.go
+++ b/encounter.go
@@ -9,7 +9,8 @@ type Encounter struct {
 }
 
 func (e *Encounter) FHIRModels() []interface{} {
-	fhirEncounter := &fhir.Encounter{Id: e.GetTempID()}
+	fhirEncounter := &fhir.Encounter{}
+	fhirEncounter.Id = e.GetTempID()
 	fhirEncounter.Status = e.convertStatus()
 	typeConcept := e.Codes.FHIRCodeableConcept(e.Description)
 	fhirEncounter.Type = []fhir.CodeableConcept{*typeConcept}

--- a/immunization.go
+++ b/immunization.go
@@ -8,7 +8,8 @@ type Immunization struct {
 }
 
 func (i *Immunization) FHIRModels() []interface{} {
-	fhirImmunization := &fhir.Immunization{Id: i.GetTempID()}
+	fhirImmunization := &fhir.Immunization{}
+	fhirImmunization.Id = i.GetTempID()
 	fhirImmunization.Status = "completed"
 	fhirImmunization.Date = i.Time.FHIRDateTime()
 	fhirImmunization.VaccineCode = i.Codes.FHIRCodeableConcept(i.Description)

--- a/medication.go
+++ b/medication.go
@@ -18,7 +18,8 @@ func (m *Medication) FHIRModels() []interface{} {
 
 func (m *Medication) convertMedication() []interface{} {
 	// TODO: Use more specific medication resources (MedicationOrder, MedicationAdministration, etc.)
-	fhirMedicationStatement := &fhir.MedicationStatement{Id: m.GetTempID()}
+	fhirMedicationStatement := &fhir.MedicationStatement{}
+	fhirMedicationStatement.Id = m.GetTempID()
 	fhirMedicationStatement.Patient = m.Patient.FHIRReference()
 	fhirMedicationStatement.Status = m.convertMedicationStatus()
 	if m.NegationInd {
@@ -78,7 +79,8 @@ func (m *Medication) convertMedicationStatus() string {
 }
 
 func (m *Medication) convertImmunization() []interface{} {
-	fhirImmunization := &fhir.Immunization{Id: m.GetTempID()}
+	fhirImmunization := &fhir.Immunization{}
+	fhirImmunization.Id = m.GetTempID()
 	fhirImmunization.Status = m.convertImmunizationStatus()
 	fhirImmunization.Date = m.StartTime.FHIRDateTime()
 	fhirImmunization.VaccineCode = m.Codes.FHIRCodeableConcept(m.Description)

--- a/patient.go
+++ b/patient.go
@@ -34,7 +34,8 @@ func (p *Patient) MatchingEncounterReference(entry Entry) *fhir.Reference {
 }
 
 func (p *Patient) FHIRModel() *fhir.Patient {
-	fhirPatient := &fhir.Patient{Id: p.GetTempID()}
+	fhirPatient := &fhir.Patient{}
+	fhirPatient.Id = p.GetTempID()
 	fhirPatient.Name = []fhir.HumanName{fhir.HumanName{Given: []string{p.FirstName}, Family: []string{p.LastName}}}
 	switch p.Gender {
 	case "M":

--- a/procedure.go
+++ b/procedure.go
@@ -43,7 +43,8 @@ func (p *Procedure) isProcedureRequest() bool {
 }
 
 func (p *Procedure) convertProcedure() []interface{} {
-	fhirProcedure := &fhir.Procedure{Id: p.GetTempID()}
+	fhirProcedure := &fhir.Procedure{}
+	fhirProcedure.Id = p.GetTempID()
 	fhirProcedure.Subject = p.Patient.FHIRReference()
 	fhirProcedure.Status = p.convertProcedureStatus()
 	fhirProcedure.Code = p.Codes.FHIRCodeableConcept(p.Description)
@@ -66,7 +67,8 @@ func (p *Procedure) convertProcedure() []interface{} {
 	if len(p.Values) > 0 {
 		// Create the diagnostic report model with its own ID and slots for results
 		internalReportID := &TemporallyIdentified{}
-		fhirReport := &fhir.DiagnosticReport{Id: internalReportID.GetTempID()}
+		fhirReport := &fhir.DiagnosticReport{}
+		fhirReport.Id = internalReportID.GetTempID()
 		fhirReport.Status = "final"
 		fhirReport.Code = &fhir.CodeableConcept{
 			Coding: []fhir.Coding{
@@ -128,7 +130,8 @@ func (p *Procedure) convertProcedureStatus() string {
 }
 
 func (p *Procedure) convertProcedureRequest() []interface{} {
-	fhirProcedureRequest := &fhir.ProcedureRequest{Id: p.GetTempID()}
+	fhirProcedureRequest := &fhir.ProcedureRequest{}
+	fhirProcedureRequest.Id = p.GetTempID()
 	fhirProcedureRequest.Subject = p.Patient.FHIRReference()
 	fhirProcedureRequest.Status = p.convertProcedureRequestStatus()
 	fhirProcedureRequest.Code = p.Codes.FHIRCodeableConcept(p.Description)

--- a/result_value.go
+++ b/result_value.go
@@ -14,7 +14,9 @@ type ResultValue struct {
 }
 
 func (v *ResultValue) FHIRModels() []interface{} {
-	observation := &fhir.Observation{Id: v.GetTempID(), Status: "final"}
+	observation := &fhir.Observation{}
+	observation.Id = v.GetTempID()
+	observation.Status = "final"
 	if v.Physical != nil {
 		if val, err := strconv.ParseFloat(v.Physical.Scalar, 64); err == nil {
 			observation.ValueQuantity = &fhir.Quantity{Unit: v.Physical.Unit, Value: &val}


### PR DESCRIPTION
See [FHIR PR #25](https://github.com/intervention-engine/fhir/pull/25) for details on support for base resources.

This PR just fixes how resources are constructed since you can no longer use `Id` very easily in the struct literals.